### PR TITLE
Gen 8 Pokedex Entries

### DIFF
--- a/pokeapi/scripts/gen8/read_swsh.py
+++ b/pokeapi/scripts/gen8/read_swsh.py
@@ -1,0 +1,214 @@
+import copy
+import os
+import struct
+import sys
+
+class TextLine():
+	offset = None
+	length = None
+
+class TextFile():
+	def __init__(this, path1, path2):
+		this.__dictEntries = {}
+		this.__magic = 0x42544841
+		this.__KEY_BASE = 0x7C89
+		this.__KEY_ADVANCE = 0x2983
+		this.__KEY_VARIABLE = 0x0010
+		this.__KEY_TERMINATOR = 0x0000
+
+		# Load dex labels
+		if (os.path.splitext(path1)[1] == ".tbl"):
+			this.__OpenTbl(path1)
+		elif (os.path.splitext(path2)[1] == ".tbl"):
+			this.__OpenTbl(path2)
+		else:
+			raise UserWarning("Error: a .tbl was not given")
+
+		# Load dex entries
+		if (os.path.splitext(path1)[1] == ".dat"):
+			this.__OpenDat(path1)
+		elif (os.path.splitext(path2)[1] == ".dat"):
+			this.__OpenDat(path2)
+		else:
+			raise UserWarning("Error: a .dat was not given")
+
+		# The table has 1 more entry than the dat to show when the table ends
+		if (len(this.__labels) == len(this.__lines) + 1):
+			for i in range(0, len(this.__lines)):
+				this.__dictEntries[this.__labels[i]] = this.__lines[i]
+
+	@property
+	def __TextSections(this):
+		"""(2 bytes) Gets the number of text sections"""
+		return struct.unpack_from("<H", this.__data, 0x0)[0]
+
+	@property
+	def __LineCount(this):
+		"""(2 bytes) Gets the amount of lines"""
+		return struct.unpack_from("<H", this.__data, 0x2)[0]
+
+	@property
+	def __TotalLength(this):
+		"""(4 bytes) Gets the total character length of all text sections"""
+		return struct.unpack_from("<I", this.__data, 0x4)[0]
+
+	@property
+	def __InitialKey(this):
+		"""(4 bytes) Gets the initial key; should be 0x00000000"""
+		return struct.unpack_from("<I", this.__data, 0x8)[0]
+
+	@property
+	def __SectionDataOffset(this):
+		"""(4 bytes) Gets the offset where the data section begins"""
+		return struct.unpack_from("<I", this.__data, 0xC)[0]
+
+	@property
+	def __SectionLength(this):
+		"""(4 bytes) Gets the length of characters the given section is"""
+		offset = this.__SectionDataOffset
+		return struct.unpack_from("<I", this.__data, offset)[0]
+
+	@property
+	def __LineOffsets(this):
+		"""Figures out the offset for each entry based on the data section offset"""
+		result = [None] * this.__LineCount
+		sdo = int(this.__SectionDataOffset)
+		for i in range(0, len(result)):
+			result[i] = TextLine()
+			result[i].offset = struct.unpack_from("<i", this.__data, (i * 8) + sdo + 4)[0] + sdo
+			result[i].length = struct.unpack_from("<h", this.__data, (i * 8) + sdo + 8)[0]
+
+		return result
+
+	def GetLabels(this):
+		return this.__labels
+
+	def GetDict(this):
+		return this.__dictEntries
+
+	def HashFNV1_64(this, word):
+		"""Fowler-Noll-Vo hash function; 64-bit"""
+		fnvPrime_64 = 0x100000001b3
+		offsetBasis_64 = 0xCBF29CE484222645
+
+		hash = offsetBasis_64
+		for c in word:
+			hash = hash ^ ord(c)
+			# Cast hash to at 64-bit value
+			hash = (hash * fnvPrime_64) % 2**64
+
+		return hash
+
+	def __LineData(this, data):
+		"""Loads the file into a list to later decrypt"""
+		key = copy.copy(this.__KEY_BASE)
+		result = [None] * this.__LineCount
+		lines = this.__LineOffsets
+
+		for i in range(0, len(lines)):
+			# Make a list twice the size of the current text line size
+			encrypted = lines[i].length * 2
+			# Then copy the encrypted line starting from the given offset for however long the given list is
+			end = lines[i].offset + encrypted
+			encrypted = this.__data[lines[i].offset:end]
+
+			result[i] = this.__CryptLineData(encrypted, key)
+			# Cast key to a 16-bits (otherwise things break)
+			key = (key + this.__KEY_ADVANCE) % 2**16
+
+		return result
+
+	def __CryptLineData(this, data, key):
+		"""Decrypts the given line into a list of bytes"""
+		copied = copy.copy(data)
+		result = [None] * len(copied)
+
+		for i in range(0, len(copied), 2):
+			result[i] = copied[i] ^ (key % 256)
+			result[i + 1] = copied[i + 1] ^ ((key >> 8) % 256)
+			# Bit-shift and OR key, then cast to 16-bits (otherwise things break)
+			key = (key << 3 | key >> 13) % 2**16
+
+		return result
+
+	def __GetLineString(this, data):
+		"""Turns the given list of bytes into a finished string"""
+		if (data is None):
+			return None
+
+		string = ""
+		i = 0
+		while (i < len(data)):
+			# Cast 2 bytes to figure out what to do next
+			value = struct.unpack_from("<H", data, i)[0]
+			if (value == this.__KEY_TERMINATOR):
+				break;
+			i += 2
+
+			if (value == this.__KEY_TERMINATOR):
+				return string
+			elif (value == this.__KEY_VARIABLE):
+				string += "[VAR]"
+			elif (value == "\n"):
+				string += "\n"
+			elif (value == "\\"):
+				string += "\\"
+			elif (value == "["):
+				string += "\["
+			else:
+				string += chr(value)
+
+		return string
+
+	def __MakeLabelHash(this, f):
+		"""Returns the label name and a FNV1_64 hash"""
+		# Next 8 bytes is the hash of the label name
+		hash = struct.unpack("<Q", f.read(8))[0]
+		# Next 2 bytes is the label"s name length
+		nameLength = struct.unpack("<H", f.read(2))[0]
+		# Read the bytes until 0x0 is found
+		name = this.__ReadUntil(f, 0x0)
+
+		if (this.HashFNV1_64(name) == hash):
+			return name, hash
+
+	def __OpenDat(this, path):
+		with open(path, "rb") as file:
+			try:
+				this.__data = file.read()
+			except:
+				raise UserWarning("Error: Could not open .dat")
+
+		# Decrypt the text
+		cryptedText = this.__LineData(this.__data)
+		this.__lines = []
+		for line in cryptedText:
+			this.__lines.append(this.__GetLineString(bytearray(line)))
+
+	def __OpenTbl(this, path):
+		with open(path, "rb") as f:
+			try:
+				# First four bytes is "magic"; needs to be 0x42544841
+				testMagic = struct.unpack("<I", f.read(4))[0]	
+				if (testMagic == this.__magic):
+					# Next four bytes is the number of entries to read
+					count = struct.unpack("<I", f.read(4))[0]
+					this.__labels = []
+					# Iterate through the entries
+					for i in range(0, count):
+						this.__labels.append(this.__MakeLabelHash(f))
+
+			except struct.error:
+				raise UserWarning("Error: Coult not open .tbl")
+
+	def __ReadUntil(this, f, value):
+		"""Reads the given file until it reaches the given value"""
+		string = ""
+		c = f.read(1)
+		end = bytes([value])
+		while (c != end):
+			# Read one byte at a time to get each character
+			string += c.decode("utf-8")
+			c = f.read(1)
+
+		return string

--- a/pokeapi/scripts/gen8/to_csv.py
+++ b/pokeapi/scripts/gen8/to_csv.py
@@ -72,12 +72,13 @@ if __name__ == "__main__":
 
 			currentEntries = []
 			# Get first line (info on what each column represents)
-			start = next(reader)
+			header = next(reader)
 			for row in reader:
 				row = [int(row[0]), int(row[1]), int(row[2]), row[3]]
 				entriesList.append(row)
 
 		# Sort the list based on species id
+		writer.writerow(header)
 		entriesList.sort()
 		writer.writerows(entriesList)
 		print("Done")

--- a/pokeapi/scripts/gen8/to_csv.py
+++ b/pokeapi/scripts/gen8/to_csv.py
@@ -1,0 +1,83 @@
+import csv
+import os
+from read_swsh import TextFile
+
+if __name__ == "__main__":
+	path = os.path.abspath(os.path.dirname(__file__))
+	fileList = os.listdir(path)
+
+	entriesList = []
+	goodFiles = []
+
+	# Get all the files in the current directory
+	for file in fileList:
+		ext = os.path.splitext(path + "\\" + file)[1]
+		# Only get the .dat and .tbl files
+		if (ext == ".tbl" or ext == ".dat"):
+			goodFiles.append(file)
+
+	# Parse through each file and put it in flavor_text
+	with open(path + "\\pokemon_species_flavor_text_updated.csv", "w", encoding = "utf-8", newline = "") as fCSV:
+		writer = csv.writer(fCSV, delimiter = ",")
+		for i in range(0, len(goodFiles), 2):
+			file1 = os.path.splitext(path + "\\" + goodFiles[i])[0]
+			file2 = os.path.splitext(path + "\\" + goodFiles[i + 1])[0]
+			# Ensure that we're wroking with the same .dat and .tbl pair
+			if (file1 == file2):
+				try:
+					print(goodFiles[i])
+					print(goodFiles[i + 1])
+					# Parse through the .dat and .tbl
+					textFile = TextFile(path + "\\" + goodFiles[i], path + "\\" + goodFiles[i + 1])
+					dictionary = textFile.GetDict()
+				except UserWarning as error:
+					print(error)
+				except Exception as error:
+					print(error)
+
+				try:
+					if (len(dictionary) == 0):
+						raise UserWarning('Error: the files returned no data')
+
+					# Get the language and game from the file's name
+					fileName = os.path.basename(path + "\\" + goodFiles[i]).lower().split("_")
+					language = int(fileName[0])
+					game = fileName[1]
+
+					version = -1
+					if game == "lgpe":
+						# Let's Go
+						version = 31
+
+					elif game == "swsh":
+						if fileName[3] == "a":
+							# Sword
+							version = 32
+						elif fileName[3] == "b":
+							# Shield
+							version = 33
+
+					# Loop through the text file's dictionary and append the parsed data into the list
+					for label, flavor_text in dictionary.items():
+						if (len(flavor_text) > 1 and "[VAR]" not in flavor_text):
+							species = int(label[0][14:17])
+							entriesList.append([species, version, language, flavor_text])
+				except UserWarning as error:
+					print(error)
+				except Exception as error:
+					print(error)
+
+		with open(path + "\\pokemon_species_flavor_text.csv", "r", encoding = "utf-8", newline = "") as fPoke:
+			reader = csv.reader(fPoke, delimiter = ",")
+
+			currentEntries = []
+			# Get first line (info on what each column represents)
+			start = next(reader)
+			for row in reader:
+				row = [int(row[0]), int(row[1]), int(row[2]), row[3]]
+				entriesList.append(row)
+
+		# Sort the list based on species id
+		entriesList.sort()
+		writer.writerows(entriesList)
+		print("Done")

--- a/pokeapi/scripts/gen8/to_csv.py
+++ b/pokeapi/scripts/gen8/to_csv.py
@@ -46,22 +46,29 @@ if __name__ == "__main__":
 
 					version = -1
 					if game == "lgpe":
-						# Let's Go
+						# Let's Go Pikachu, then Eevee
 						version = 31
+						dupe = True
 
 					elif game == "swsh":
+						dupe = False
 						if fileName[3] == "a":
 							# Sword
-							version = 32
+							version = 33
 						elif fileName[3] == "b":
 							# Shield
-							version = 33
+							version = 34
 
 					# Loop through the text file's dictionary and append the parsed data into the list
 					for label, flavor_text in dictionary.items():
 						if (len(flavor_text) > 1 and "[VAR]" not in flavor_text):
 							species = int(label[0][14:17])
 							entriesList.append([species, version, language, flavor_text])
+
+							# Append a duplicate entry for Let's Go Eevee (both games use the same table)
+							if (dupe):
+								entriesList.append([species, 32, language, flavor_text])
+
 				except UserWarning as error:
 					print(error)
 				except Exception as error:
@@ -74,6 +81,7 @@ if __name__ == "__main__":
 			# Get first line (info on what each column represents)
 			header = next(reader)
 			for row in reader:
+				# species_id, version_id, language_id, flavor_text
 				row = [int(row[0]), int(row[1]), int(row[2]), row[3]]
 				entriesList.append(row)
 

--- a/pokedex/data/csv/version_group_regions.csv
+++ b/pokedex/data/csv/version_group_regions.csv
@@ -18,3 +18,5 @@ version_group_id,region_id
 16,3
 17,7
 18,7
+19,1
+20,8

--- a/pokedex/data/csv/version_groups.csv
+++ b/pokedex/data/csv/version_groups.csv
@@ -17,3 +17,5 @@ id,identifier,generation_id,order
 16,omega-ruby-alpha-sapphire,6,16
 17,sun-moon,7,17
 18,ultra-sun-ultra-moon,7,18
+19,lets-go,7,19
+20,sword-shield,8,20

--- a/pokedex/data/csv/versions.csv
+++ b/pokedex/data/csv/versions.csv
@@ -29,3 +29,6 @@ id,version_group_id,identifier
 28,17,moon
 29,18,ultra-sun
 30,18,ultra-moon
+31,19,lets-go
+32,20,sword
+33,20,shield

--- a/pokedex/data/csv/versions.csv
+++ b/pokedex/data/csv/versions.csv
@@ -29,6 +29,7 @@ id,version_group_id,identifier
 28,17,moon
 29,18,ultra-sun
 30,18,ultra-moon
-31,19,lets-go
-32,20,sword
-33,20,shield
+31,19,lets-go-pikachu
+32,19,lets-go-eevee
+33,20,sword
+34,20,shield


### PR DESCRIPTION
I dumped my copies of each Pokemon title on the Switch and grabbed their respective dex entries (found at romfs/bin/message/<language>/common/zukan_comment_A or B) and ported pkNX's TextFile.cs to a python 3 script, read_swsh.py, that parses the data into a useable list. Then,  to_csv.py turns the data into a CVS. 

Sword and Shield keep both dex entry versions in their file system, so you only need one game to get both versions.
NOTE: You must dump the romfs from SwSh v1.2.0 or later to get the DLC dex entries.

Let's Go Pikachu / Eevee only use one dex entry version, so you only need one game.

### HOW TO

To use the script, put each zukan_comment .dat and .tbl from each language and game into a folder with the script and rename each zukan_comment to the syntax as follows: 


> <language_id>_<swsh / lgpe>__comment_<A or B>.dat / .tbl


I put the language name at the end to differentiate which file contained what language, but the script doesn't need it.

Before
![before](https://user-images.githubusercontent.com/68128075/91264221-699e2700-e725-11ea-92d7-a0f823e44f41.png)

After
![example](https://user-images.githubusercontent.com/68128075/91261137-8dad3880-e724-11ea-863c-9a97e512a157.png)

Finally, copy [pokemon_species_flavor_text.csv](https://github.com/PokeAPI/pokedex/blob/master-pokeapi/pokedex/data/csv/pokemon_species_flavor_text.csv) into the folder, and run to_csv.py. An updated CSV will be created with the gen 8 entries.

This is what it should look like before you run to_csv.py.
![script](https://user-images.githubusercontent.com/68128075/91269170-83426d00-e72b-11ea-9f4d-fa4a2cca4e5c.png)

[Here is a zip with only the lgpe and swsh entries.](https://github.com/PokeAPI/pokedex/files/5127991/gen8_data_only.zip)


