### PR TITLE
Fix typo in Zamazenta french name

### DIFF
--- a/pokedex/data/csv/pokemon_species_names.csv
+++ b/pokedex/data/csv/pokemon_species_names.csv
@@ -9375,7 +9375,7 @@ pokemon_species_id,local_language_id,name,genus
 889,1,ザマゼンタ,つわものポケモン
 889,3,자마젠타,강자포켓몬
 889,4,藏瑪然特,強者寶可夢
-889,5,Zamazent,Pokémon Valeureux
+889,5,Zamazenta,Pokémon Valeureux
 889,6,Zamazenta,Krieger
 889,7,Zamazenta,Pokémon Guerrero
 889,8,Zamazenta,Pokémon Guerriero


### PR DESCRIPTION
I was seeing this issue and fix the name of Zamazenta in French #42 
I check the name of Zamazenta in french from https://bulbapedia.bulbagarden.net/wiki/Zamazenta_(Pok%C3%A9mon)#In_other_languages